### PR TITLE
fix ID handling in toString

### DIFF
--- a/src/DotLang.elm
+++ b/src/DotLang.elm
@@ -36,7 +36,7 @@ Take a look at the grammar <https://www.graphviz.org/doc/info/lang.html>
 import DoubleQuoteString as DQS
 import Html.Parser exposing (Node(..), node, nodeToString)
 import Parser exposing (..)
-import Set
+import Set exposing (Set)
 
 
 {-| Parse a DOT string.
@@ -681,11 +681,11 @@ showId : ID -> String
 showId id_ =
     case id_ of
         ID str ->
-            let
-                escaped =
-                    String.replace "\"" "\\\"" str
-            in
-            if String.contains " " str || String.contains "\"" str then
+            if shouldBeQuoted str then
+                let
+                    escaped =
+                        String.replace "\"" "\\\"" str
+                in
                 "\"" ++ escaped ++ "\""
 
             else
@@ -696,6 +696,44 @@ showId id_ =
 
         NumeralID float ->
             String.fromFloat float
+
+
+shouldBeQuoted : String -> Bool
+shouldBeQuoted s =
+    String.isEmpty s || beginsWithADigit s || hasACharacterNotInWhiteList s
+
+
+isInWhiteList : Char -> Bool
+isInWhiteList char =
+    List.any identity
+        [ Char.isLower char
+        , Char.isUpper char
+        , '_' == char
+        , Char.isDigit char
+        , Set.member char asciiOctalFrom200To377
+        ]
+
+
+asciiOctalFrom200To377 : Set Char
+asciiOctalFrom200To377 =
+    List.range 200 377
+        |> List.map Char.fromCode
+        |> Set.fromList
+
+
+beginsWithADigit : String -> Bool
+beginsWithADigit string =
+    case String.uncons string of
+        Just ( c, _ ) ->
+            Char.isDigit c
+
+        Nothing ->
+            False
+
+
+hasACharacterNotInWhiteList : String -> Bool
+hasACharacterNotInWhiteList =
+    String.any (isInWhiteList >> not)
 
 
 showNodeId : NodeId -> String

--- a/src/DotLang.elm
+++ b/src/DotLang.elm
@@ -716,7 +716,10 @@ isInWhiteList char =
 
 asciiOctalFrom200To377 : Set Char
 asciiOctalFrom200To377 =
-    List.range 200 377
+    -- DOT says: "Any string of alphabetic ([a-zA-Z\200-\377]) characters"
+    -- \200-\377 in octal is \128-\255 in decimal according to this table:
+    -- https://www.autoitscript.com/autoit3/docs/appendix/ascii.htm
+    List.range 128 255
         |> List.map Char.fromCode
         |> Set.fromList
 

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -767,4 +767,17 @@ testToString =
                 Expect.equal
                     (Result.map toString (fromString g))
                     (Ok g)
+        , test "can handle hex codes" <|
+            \_ ->
+                let
+                    g =
+                        String.join "\n"
+                            [ "graph {"
+                            , "    color=\"#ffffff\""
+                            , "}"
+                            ]
+                in
+                Expect.equal
+                    (Result.map toString (fromString g))
+                    (Ok g)
         ]

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -780,4 +780,30 @@ testToString =
                 Expect.equal
                     (Result.map toString (fromString g))
                     (Ok g)
+        , test "can handle JSON" <|
+            \_ ->
+                let
+                    g =
+                        String.join "\n"
+                            [ "graph {"
+                            , "    a -- \"{ \\\"key\\\": [ 123 ] }\""
+                            , "}"
+                            ]
+                in
+                Expect.equal
+                    (Result.map toString (fromString g))
+                    (Ok g)
+        , test "can handle empty ID strings" <|
+            \_ ->
+                let
+                    g =
+                        String.join "\n"
+                            [ "graph {"
+                            , "    a -- \"\""
+                            , "}"
+                            ]
+                in
+                Expect.equal
+                    (Result.map toString (fromString g))
+                    (Ok g)
         ]


### PR DESCRIPTION
fixes #3, fixes #5 

@erkal did most of the work in [this comment](https://github.com/brandly/elm-dot-lang/issues/5#issuecomment-480182906) 🙏 

to reiterate, an ID in DOT can be

> Any string of alphabetic ([a-zA-Z\200-\377]) characters, underscores ('_') or digits ([0-9]), not beginning with a digit;

as well as

> any double-quoted string ("...") possibly containing escaped quotes (\")

we were doing a poor job detecting when the double-quotes were needed, but now, i think our `showId` definition closely mirrors the language spec.

---

@erkal could you look this over? i'm still not sure if we're handling the `\200-\377` correctly. sometimes, [i go to graphviz](http://viz-js.com/) to see what parses and what fails. if i take characters like `Char.fromCode 378` and put them in an ID _without_ any quotes, it still parses just fine!

there may still be shortcomings in this package in terms of parsing those characters, but i guess it won't cause any problems if we wrap an ID in quotes when it doesn't need them.

let me know what you think of everything.