### PR TITLE
fix fuzz tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
     fi
 
 script:
-  - "$TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 npm run test-ci"
+  - "$TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 npm test"
 
 cache:
   directories:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "scripts": {
-    "test": "elm-test --fuzz 1",
-    "test-ci": "npm test -- --seed 277939263651816"
+    "test": "elm-test"
   },
   "dependencies": {
     "elm": "0.19.1-3",

--- a/src/DotLang.elm
+++ b/src/DotLang.elm
@@ -385,17 +385,22 @@ type ID
     | NumeralID Float
 
 
+unquotedVariable : Parser String
+unquotedVariable =
+    variable
+        { start = \c -> Char.isAlpha c || c == '_'
+        , inner = \c -> Char.isAlphaNum c || c == '_'
+        , reserved = Set.fromList []
+        }
+
+
 id : Parser ID
 id =
     oneOf
         [ map ID <|
             oneOf
                 [ DQS.string
-                , variable
-                    { start = \c -> Char.isAlpha c || c == '_'
-                    , inner = \c -> Char.isAlphaNum c || c == '_'
-                    , reserved = Set.fromList []
-                    }
+                , unquotedVariable
                 ]
         , succeed HtmlID
             |. symbol "<"
@@ -440,18 +445,52 @@ port_ =
         |. symbol ":"
         |. spacing
         |= oneOf
-            [ succeed PortPt
-                |= compassPt
+            [ unquotedVariable
+                |> andThen
+                    (\var ->
+                        {- If a token is like `c0` and we directly parse a
+                           `compassPt`, the parser will be greedy and claim the
+                           `c` leaving the 0 behind.
+                        -}
+                        if isCompassPt var then
+                            succeed
+                                (PortPt
+                                    (compassPtMapping
+                                        |> List.filterMap
+                                            (\( v, compass ) ->
+                                                if v == var then
+                                                    Just compass
+
+                                                else
+                                                    Nothing
+                                            )
+                                        |> List.head
+                                        -- Already check that it `isCompassPt`,
+                                        -- so this won't get hit.
+                                        |> Maybe.withDefault UND
+                                    )
+                                )
+
+                        else
+                            succeed (PortId (ID var))
+                                |. spacing
+                                |= portIdSuffix
+                    )
             , succeed PortId
                 |= id
                 |. spacing
-                |= maybeParse
-                    (succeed identity
-                        |. symbol ":"
-                        |. spacing
-                        |= compassPt
-                    )
+                |= portIdSuffix
             ]
+
+
+portIdSuffix : Parser (Maybe CompassPt)
+portIdSuffix =
+    maybeParse
+        (succeed identity
+            |. symbol ":"
+            |. spacing
+            |= compassPt
+        )
 
 
 {-| A `CompassPt` describes the 8 compass directions, as well as `C` for
@@ -472,19 +511,23 @@ type CompassPt
 
 compassPt : Parser CompassPt
 compassPt =
-    symbolToType
-        -- this order matters due to `symbol` being greedy
-        [ ( "ne", NE )
-        , ( "nw", NW )
-        , ( "se", SE )
-        , ( "sw", SW )
-        , ( "n", N )
-        , ( "e", E )
-        , ( "s", S )
-        , ( "w", W )
-        , ( "c", C )
-        , ( "_", UND )
-        ]
+    symbolToType compassPtMapping
+
+
+compassPtMapping : List ( String, CompassPt )
+compassPtMapping =
+    -- this order matters due to `symbol` being greedy
+    [ ( "ne", NE )
+    , ( "nw", NW )
+    , ( "se", SE )
+    , ( "sw", SW )
+    , ( "n", N )
+    , ( "e", E )
+    , ( "s", S )
+    , ( "w", W )
+    , ( "c", C )
+    , ( "_", UND )
+    ]
 
 
 comment : Parser ()
@@ -683,7 +726,12 @@ toStringWithConfig config (Dot type_ maybeId stmts) =
 
 
 showId : ID -> String
-showId id_ =
+showId =
+    showIdWithQuotes shouldBeQuotedDefault
+
+
+showIdWithQuotes : (String -> Bool) -> ID -> String
+showIdWithQuotes shouldBeQuoted id_ =
     case id_ of
         ID str ->
             if shouldBeQuoted str then
@@ -705,13 +753,13 @@ showId id_ =
             String.fromFloat float
 
 
-shouldBeQuoted : String -> Bool
-shouldBeQuoted s =
+shouldBeQuotedDefault : String -> Bool
+shouldBeQuotedDefault s =
     String.isEmpty s || beginsWithADigit s || hasACharacterNotInWhiteList s || isKeyword s
 
 
-isInWhiteList : Char -> Bool
-isInWhiteList char =
+isInAllowList : Char -> Bool
+isInAllowList char =
     List.any identity
         [ Char.isLower char
         , Char.isUpper char
@@ -743,7 +791,7 @@ beginsWithADigit string =
 
 hasACharacterNotInWhiteList : String -> Bool
 hasACharacterNotInWhiteList =
-    String.any (isInWhiteList >> not)
+    String.any (isInAllowList >> not)
 
 
 isKeyword : String -> Bool
@@ -792,7 +840,12 @@ showPort : Port -> String
 showPort port__ =
     case port__ of
         PortId id__ maybeCompassPt ->
-            showId id__
+            let
+                shouldBeQuoted : String -> Bool
+                shouldBeQuoted str =
+                    shouldBeQuotedDefault str || isCompassPt str
+            in
+            showIdWithQuotes shouldBeQuoted id__
                 ++ (maybeCompassPt
                         |> Maybe.map (showCompassPt >> String.cons ':')
                         |> Maybe.withDefault ""
@@ -834,3 +887,13 @@ showCompassPt compassPt_ =
 
         UND ->
             "_"
+
+
+compassPts : Set String
+compassPts =
+    Set.fromList (List.map Tuple.first compassPtMapping)
+
+
+isCompassPt : String -> Bool
+isCompassPt str =
+    Set.member (String.toLower str) compassPts

--- a/src/DotLang.elm
+++ b/src/DotLang.elm
@@ -689,7 +689,9 @@ showId id_ =
             if shouldBeQuoted str then
                 let
                     escaped =
-                        String.replace "\"" "\\\"" str
+                        str
+                            |> String.replace "\\" "\\\\"
+                            |> String.replace "\"" "\\\""
                 in
                 "\"" ++ escaped ++ "\""
 

--- a/src/DoubleQuoteString.elm
+++ b/src/DoubleQuoteString.elm
@@ -25,6 +25,7 @@ stringHelp revChunks =
                 , map (\_ -> "\t") (token "t")
                 , map (\_ -> "\u{000D}") (token "r")
                 , map (\_ -> "\"") (token "\"")
+                , map (\_ -> "\\") (token "\\")
                 , succeed String.fromChar
                     |. token "u{"
                     |= unicode

--- a/tests/FuzzTests.elm
+++ b/tests/FuzzTests.elm
@@ -46,20 +46,20 @@ fuzzStmts depth =
         (oneOf
             [ map2 NodeStmt
                 fuzzNodeId
-                (shortList fuzzAttr)
+                (list fuzzAttr)
             , map4 EdgeStmtNode
                 fuzzNodeId
                 (fuzzEdgeRHS depth)
                 (shortList (fuzzEdgeRHS depth))
-                (shortList fuzzAttr)
+                (list fuzzAttr)
             , map4 EdgeStmtSubgraph
                 (fuzzSubgraph depth)
                 (fuzzEdgeRHS depth)
                 (shortList (fuzzEdgeRHS depth))
-                (shortList fuzzAttr)
+                (list fuzzAttr)
             , map2 AttrStmt
                 fuzzAttrStmtType
-                (shortList fuzzAttr)
+                (list fuzzAttr)
             , map LooseAttr fuzzAttr
             , map SubgraphStmt (fuzzSubgraph depth)
             ]

--- a/tests/FuzzTests.elm
+++ b/tests/FuzzTests.elm
@@ -42,28 +42,33 @@ fuzzId =
 
 fuzzStmts : Int -> Fuzzer (List Stmt)
 fuzzStmts depth =
-    list
+    shortList
         (oneOf
             [ map2 NodeStmt
                 fuzzNodeId
-                (list fuzzAttr)
+                (shortList fuzzAttr)
             , map4 EdgeStmtNode
                 fuzzNodeId
                 (fuzzEdgeRHS depth)
-                (list (fuzzEdgeRHS depth))
-                (list fuzzAttr)
+                (shortList (fuzzEdgeRHS depth))
+                (shortList fuzzAttr)
             , map4 EdgeStmtSubgraph
                 (fuzzSubgraph depth)
                 (fuzzEdgeRHS depth)
-                (list (fuzzEdgeRHS depth))
-                (list fuzzAttr)
+                (shortList (fuzzEdgeRHS depth))
+                (shortList fuzzAttr)
             , map2 AttrStmt
                 fuzzAttrStmtType
-                (list fuzzAttr)
+                (shortList fuzzAttr)
             , map LooseAttr fuzzAttr
             , map SubgraphStmt (fuzzSubgraph depth)
             ]
         )
+
+
+shortList : Fuzzer a -> Fuzzer (List a)
+shortList fuzzer =
+    map3 (\a b c -> [ a, b, c ]) fuzzer fuzzer fuzzer
 
 
 fuzzNodeId : Fuzzer NodeId


### PR DESCRIPTION
fixes #9 

`list` sometimes [generates longer lists](https://github.com/elm-explorations/test/blob/b639def0fdb3437cd076d4ed840cb2451c553f7c/src/Fuzz.elm#L390), and `fuzzStmts` has some nested `list`s. i'm using `shortList` on more complex fuzzers now, which consistently produces a `List` with a length of just 3. this allows the fuzz tests to run smoothly and not run out of memory.

the existing fuzz test setup had revealed some bugs, but now that the tests are running smoothly, they revealed more bugs!
* `/` in a node id wouldn't be properly escaped. once it was escaped, the node id parser couldn't parse the `//` back into a `/`.
* a `PortId` with an `(ID "w")` would be parsed back in as `PortPt W`, where `W` is a `CompassPt`. now, it'll print out the `ID` as `"w"` with quotes, not to be confused with `w`, the compass pt.

i think the parser handles these compass pts correctly now. [the grammar](https://www.graphviz.org/doc/info/lang.html) looks like this:
```
port : ':' ID [ ':' compass_pt ]
     | ':' compass_pt
```

`w` definitely _could_ be an `ID` but then you'd never fall through to the `compass_pt` below. now, i parse a `unquotedVariable`, check if it's a valid compass pt, and decide which fork to head down.

with these changes, i haven't seen any fuzz tests fail. since they're reliably running and passing, CI now runs `elm-test` with the full `--fuzz 100`.